### PR TITLE
Fixed Pinterest URL paramter

### DIFF
--- a/js/stores/AppStore.js
+++ b/js/stores/AppStore.js
@@ -218,7 +218,7 @@ var AppStore = assign({}, EventEmitter.prototype, {
 			'twitter': 'https://twitter.com/intent/tweet/?text=' + text + '&url=' + url,
 			'google': 'https://plus.google.com/share?url=' + url,
 			'tumblr': "https://www.tumblr.com/widgets/share/tool?posttype=link&title=" + text + "&caption=" + text + "&content=" + url + "&canonicalUrl=" + url + "&shareSource=tumblr_share_button",
-			'pinterest': 'https://pinterest.com/pin/create/button/?url=' + url + '&media=' + url + '&summary=' + text,
+			'pinterest': 'https://pinterest.com/pin/create/button/?url=' + url + '&media=' + url + '&description=' + text,
 			'linkedin': 'https://www.linkedin.com/shareArticle?mini=true&url=' + url + '&title=' + text + '&summary=' + text + '&source=' + url,
 			'reddit': 'https://reddit.com/submit/?url=' + url,
 			'email': 'mailto:?subject=' + text + '&body=' + url,


### PR DESCRIPTION
Pinterest doesn't work with the parameter 'summary='. It only shows a dark screen. It needs the parameter 'description=' instead.

Fixes this issue: https://github.com/mxstbr/sharingbuttons.io/issues/66