### PR TITLE
Correct git url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mstoiber/sharing.git"
+    "url": "git://github.com/mxstbr/sharingbuttons.io.git"
   },
   "author": "Max Stoiber",
   "license": "MIT"


### PR DESCRIPTION
It seems like the project was renamed on GitHub so I updated the package.json field accordingly.